### PR TITLE
Read the SMTP password from a file as opposed to the command-line argument

### DIFF
--- a/README
+++ b/README
@@ -77,6 +77,7 @@ Synopsis:  sendEmail -f ADDRESS [options]
     -bcc ADDRESS [ADDR ...]   bcc email address(es)
     -xu  USERNAME             username for SMTP authentication
     -xp  PASSWORD             password for SMTP authentication
+    -xp-file FILE             read the password for SMTP from FILE
 
   Paranormal:
     -b BINDADDR[:PORT]        local host bind address

--- a/README
+++ b/README
@@ -77,7 +77,7 @@ Synopsis:  sendEmail -f ADDRESS [options]
     -bcc ADDRESS [ADDR ...]   bcc email address(es)
     -xu  USERNAME             username for SMTP authentication
     -xp  PASSWORD             password for SMTP authentication
-    -xp-file FILE             read the password for SMTP from FILE
+    -xp-file FILE             read the password for SMTP server from FILE
 
   Paranormal:
     -b BINDADDR[:PORT]        local host bind address

--- a/README
+++ b/README
@@ -77,11 +77,7 @@ Synopsis:  sendEmail -f ADDRESS [options]
     -bcc ADDRESS [ADDR ...]   bcc email address(es)
     -xu  USERNAME             username for SMTP authentication
     -xp  PASSWORD             password for SMTP authentication
-<<<<<<< HEAD
     -xp-file FILE             read the password for SMTP server from FILE
-=======
-    -xp-file FILE             read the password for SMTP from FILE
->>>>>>> e41cf4fab13c90293a81859576561af73727dd6f
 
   Paranormal:
     -b BINDADDR[:PORT]        local host bind address

--- a/sendEmail
+++ b/sendEmail
@@ -366,6 +366,13 @@ sub processCommandLine {
             }
         }
         
+        elsif ($ARGS[$counter] =~ /^-xp-file$/) {             ## AuthSMTP Password in a file ##
+            $counter++;
+            open my $pfile, '<', $ARGS[$counter]; 
+            $opt{'password'} = <$pfile>; 
+            close $pfile;
+        }
+
         elsif ($ARGS[$counter] =~ /^-xp$/) {                  ## AuthSMTP Password ##
             $counter++;
             if ($ARGS[$counter] && $ARGS[$counter] !~ /^-/) {
@@ -1300,6 +1307,7 @@ Synopsis:  $conf{'programName'} -f ADDRESS [options]
     -bcc ADDRESS [ADDR ...]   bcc email address(es)
     -xu  USERNAME             username for SMTP authentication
     -xp  PASSWORD             password for SMTP authentication
+    -xp-file FILE             read from file the password for SMTP authentication
 
   ${colorGreen}Paranormal:${colorNormal}
     -b BINDADDR[:PORT]        local host bind address
@@ -1567,6 +1575,7 @@ Options that don't fit anywhere else:
     -a   ATTACHMENT [ATTACHMENT ...]
     -xu  USERNAME
     -xp  PASSWORD
+    -xp-file FILE
     -o   username=USERNAME
     -o   password=PASSWORD
     -o   tls=<auto|yes|no>
@@ -1583,6 +1592,9 @@ Options that don't fit anywhere else:
 
 -xp  PASSWORD
     Alias for -o password=PASSWORD
+
+-xp-file  FILE
+    Read the SMTP server password from the specified FILE.
 
 -o   username=USERNAME (synonym for -xu)
     These options allow specification of a username to be used with SMTP


### PR DESCRIPTION
The [-xp PASSWDORD] option can be considered a security hole since allows anybody logged on the node to inspect the process arguments and intercept the value with "ps" os through the /proc/ FS.

This patch introduces the additional option [-xp-file FILE] which tells the program to read the password from the FILE. This is more secure, since the file permissions can be set to restrict access according to Unix owner/groups.
