### PR TITLE
chinese_attach_filename_support

### DIFF
--- a/debian/patches/chinese_attach_filename_support.patch
+++ b/debian/patches/chinese_attach_filename_support.patch
@@ -1,0 +1,27 @@
+--- a/sendEmail	2016-06-12 15:52:30.000000000 +0800
++++ b/sendEmail	2016-06-12 16:06:25.000000000 +0800
+@@ -37,7 +37,8 @@
+ ##############################################################################
+ use strict;
+ use IO::Socket;
+-
++use Encode;
++use Encode::Locale;
+ 
+ ########################
+ ##  Global Variables  ##
+@@ -922,9 +923,12 @@
+     
+     $y  = "$CRLF--$conf{'delimiter'}$CRLF";
+     $y .= "Content-Type: $content_type;$CRLF";
+-    $y .= "        name=\"$filename_name\"$CRLF";
+     $y .= "Content-Transfer-Encoding: base64$CRLF";
+-    $y .= "Content-Disposition: attachment; filename=\"$filename_name\"$CRLF";
++
++    
++    my $utf8_fname = uc( unpack( "H*", encode('utf8' => decode( locale => $filename_name ))));
++    $utf8_fname =~ s/(..)/%$1/g;
++    $y .= "Content-Disposition: attachment; filename*=UTF-8''$utf8_fname$CRLF";
+     $y .= "$CRLF";
+     print $SERVER $y;
+     

--- a/sendEmail
+++ b/sendEmail
@@ -37,7 +37,8 @@
 ##############################################################################
 use strict;
 use IO::Socket;
-
+use Encode;
+use Encode::Locale;
 
 ########################
 ##  Global Variables  ##
@@ -922,9 +923,12 @@ sub send_attachment {
     
     $y  = "$CRLF--$conf{'delimiter'}$CRLF";
     $y .= "Content-Type: $content_type;$CRLF";
-    $y .= "        name=\"$filename_name\"$CRLF";
     $y .= "Content-Transfer-Encoding: base64$CRLF";
-    $y .= "Content-Disposition: attachment; filename=\"$filename_name\"$CRLF";
+
+    
+    my $utf8_fname = uc( unpack( "H*", encode('utf8' => decode( locale => $filename_name ))));
+    $utf8_fname =~ s/(..)/%$1/g;
+    $y .= "Content-Disposition: attachment; filename*=UTF-8''$utf8_fname$CRLF";
     $y .= "$CRLF";
     print $SERVER $y;
     


### PR DESCRIPTION
I encountered some encoding problem when send email attachment with non-ascii filename, as these 2 posts described:

[Sending MIME-encoded email attachments with utf-8 filenames](http://stackoverflow.com/questions/27435066/sending-mime-encoded-email-attachments-with-utf-8-filenames)

[How to encode the filename parameter of Content-Disposition header in HTTP?](http://stackoverflow.com/questions/93551/how-to-encode-the-filename-parameter-of-content-disposition-header-in-http/6745788#6745788)

so I create a patch to add non-ascii attach filename support.

Example : 

sendEmail -u 华夏 -m 华夏 -o message-charset=utf8 -f  xxx@xxx.com -t yyy@yyy.com -a 华夏.txt
