### PR TITLE
Fix dot stuffing bug

### DIFF
--- a/sendEmail
+++ b/sendEmail
@@ -1821,6 +1821,9 @@ $message =~ s/(\015)(\012|$)?/\015\012/g;
 ## Check message for bare periods and encode them
 $message =~ s/(^|$CRLF)(\.{1})($CRLF|$)/$1.$2$3/g;
 
+## Check message for lines that begin with a period and stuff them
+$message =~ s/(^|$LTERM)\./$1../g;
+
 ## Get the current date for the email header
 my ($sec,$min,$hour,$mday,$mon,$year,$day) = gmtime();
 $year += 1900; $mon = return_month($mon); $day = return_day($day);


### PR DESCRIPTION
See:
http://stackoverflow.com/questions/15224224/smtp-dot-stuffing-when-and-where-to-do-it
http://tools.ietf.org/html/rfc5321#section-4.5.2

According to the SMTP standard RFC 5321, section 4.5.2:
> To allow all user composed text to be transmitted transparently, the following procedures are used:
> * Before sending a line of mail text, the SMTP client checks the first character of the line. If it is a period, one additional period is inserted at the beginning of the line.
> * When a line of mail text is received by the SMTP server, it checks the line. If the line is composed of a single period, it is treated as the end of mail indicator. If the first character is a period and there are other characters on the line, the first character is deleted.

The current version of sendemail **DOES** pad lines consisting *ONLY* of a single period (`.`), but **DOES NOT** pad lines that begin with a period with another period. The result of this behavior is that mails sent via sendemail are received with that first period truncated.

For example, if you send an e-mail with the body text:
> .
> .test

You will receive that e-mail with the following body text:
> .
> test

This bug is fixed by doing a regexp search for all lines in `$message` beginning with a `.` and replace with `..`.