### PR TITLE
Update Homepage URL

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Alejandro Garrido Mota <alejandro@debian.org>
 Build-Depends: debhelper (>= 9)
 Standards-Version: 3.9.4
-Homepage: http://www.caspian.dotconf.net/menu/Software/SendEmail/
+Homepage: http://caspian.dotconf.net/menu/Software/SendEmail/
 Vcs-Git: git://github.com/mogaal/sendemail.git
 Vcs-Browser: https://github.com/mogaal/sendemail
 


### PR DESCRIPTION
The Homepage info in control file (http://www.caspian.dotconf.net/menu/Software/SendEmail/) is invalid because the domain
is not known:

```
$ LANG=C; wget http://www.caspian.dotconf.net/menu/Software/SendEmail/
--2017-12-15 14:56:56--
http://www.caspian.dotconf.net/menu/Software/SendEmail/
Resolving www.caspian.dotconf.net (www.caspian.dotconf.net)... failed: Name
or service not known.
wget: unable to resolve host address 'www.caspian.dotconf.net'
```

This PR fixes #884459 in bugs.debian.org.