### PR TITLE
changing SSL version to Perl SSL.pm default values

### DIFF
--- a/sendEmail
+++ b/sendEmail
@@ -1903,7 +1903,7 @@ else {
     if ($conf{'tls_server'} == 1 and $conf{'tls_client'} == 1 and $opt{'tls'} =~ /^(yes|auto)$/) {
         printmsg("DEBUG => Starting TLS", 2);
         if (SMTPchat('STARTTLS')) { quit($conf{'error'}, 1); }
-        if (! IO::Socket::SSL->start_SSL($SERVER, SSL_version => 'SSLv3 TLSv1')) {
+        if (! IO::Socket::SSL->start_SSL($SERVER, SSL_version => 'SSLv23:!SSLv3:!SSLv2')) {
             quit("ERROR => TLS setup failed: " . IO::Socket::SSL::errstr(), 1);
         }
         printmsg("DEBUG => TLS: Using cipher: ". $SERVER->get_cipher(), 3);


### PR DESCRIPTION
As SSL evolves using TLSv1 were forbidden on many servers because of security
issues.

Some people exchanged workarounds at
https://unix.stackexchange.com/questions/53065/invalid-ssl-version-specified-at-usr-share-perl5-io-socket-ssl-pm-line-332

This change uses SSL options used by Perl 5 at
 /usr/share/perl5/IO/Socket/SSL.pm:133 (below) and worked fine.

--------------------------------------------------------------------------------
 SSL_version => 'SSLv23:!SSLv3:!SSLv2', # consider both SSL3.0 and SSL2.0 as broken
--------------------------------------------------------------------------------