### PR TITLE
Corrected TLS usage of IO::Socket::SSL

### DIFF
--- a/sendEmail
+++ b/sendEmail
@@ -61,11 +61,11 @@ my %conf = (
     
     ## Network
     "server"               => 'localhost',                         ## Default SMTP server
-    "port"                 => 25,                                  ## Default port
+    "port"                 => 587,                                 ## Default port
     "bindaddr"             => '',                                  ## Default local bind address
     "alarm"                => '',                                  ## Default timeout for connects and reads, this gets set from $opt{'timeout'}
-    "tls_client"           => 0,                                   ## If TLS is supported by the client (us)
-    "tls_server"           => 0,                                   ## If TLS is supported by the remote SMTP server
+    "tls_client"           => 1,                                   ## If TLS is supported by the client (us)
+    "tls_server"           => 1,                                   ## If TLS is supported by the remote SMTP server
     
     ## Email
     "delimiter"            => "----MIME delimiter for sendEmail-"  ## MIME Delimiter
@@ -1903,7 +1903,12 @@ else {
     if ($conf{'tls_server'} == 1 and $conf{'tls_client'} == 1 and $opt{'tls'} =~ /^(yes|auto)$/) {
         printmsg("DEBUG => Starting TLS", 2);
         if (SMTPchat('STARTTLS')) { quit($conf{'error'}, 1); }
-        if (! IO::Socket::SSL->start_SSL($SERVER, SSL_version => 'SSLv3 TLSv1')) {
+        # original code not working because IO:SSL now requires SSL parameters
+        #if (! IO::Socket::SSL->start_SSL($SERVER, SSL_version => 'SSLv3 TLSv1')) {
+        # disable ssl verify mode (does not veryfy trusted certs, INSECURE as it allows man in the middle attacks)
+        #if (! IO::Socket::SSL->start_SSL($SERVER, SSL_version => 'TLSv1', SSL_verify_mode => 'SSL_VERIFY_NONE' )) {
+        # force tlsv1 and pass the location of the CA bundle
+        if (! IO::Socket::SSL->start_SSL($SERVER, SSL_version => 'TLSv1', SSL_cert_file => '/etc/pki/tls/certs/ca-bundle.crt' )) {
             quit("ERROR => TLS setup failed: " . IO::Socket::SSL::errstr(), 1);
         }
         printmsg("DEBUG => TLS: Using cipher: ". $SERVER->get_cipher(), 3);


### PR DESCRIPTION
IO::Socket::SSL requires CA bundle location to be defined

Still using this script in 2020! 👍 

NOTE: I'm not an expert just needed this to work and found a way!

Tested with Gmail TLS on port 587

[13:29 srvXXXXX ~]# /usr/bin/sendemail -t to@gmail.com -f from@gmail.com -u TESTSUBJECT -m TESTMESSAGE -s smtp.gmail.com:587 -xu from@gmail.com -xp password -v -v -o tls=yes
Aug 02 13:29:54 srvXXXXX sendemail[13611]: DEBUG => Connecting to smtp.gmail.com:587
Aug 02 13:29:55 srvXXXXX sendemail[13611]: DEBUG => My IP address is: 192.168.X.XX
Aug 02 13:29:55 srvXXXXX sendemail[13611]: DEBUG => evalSMTPresponse() - Found SMTP success code: 220
Aug 02 13:29:55 srvXXXXX sendemail[13611]: SUCCESS => Received:         220 smtp.gmail.com ESMTP n11sm12221358wmi.15 - gsmtp
Aug 02 13:29:55 srvXXXXX sendemail[13611]: INFO => Sending:     EHLO srvXXXXX
Aug 02 13:29:55 srvXXXXX sendemail[13611]: DEBUG => evalSMTPresponse() - Found SMTP success code: 250
Aug 02 13:29:55 srvXXXXX sendemail[13611]: SUCCESS => Received:         250-smtp.gmail.com at your service, [85.244.XX.XX], 250-SIZE 35882577, 250-8BITMIME, 250-STARTTLS, 250-ENHANCEDSTATUSCODES, 250-PIPELINING, 250-CHUNKING, 250 SMTPUTF8
Aug 02 13:29:55 srvXXXXX sendemail[13611]: DEBUG => The remote SMTP server supports TLS :)
Aug 02 13:29:55 srvXXXXX sendemail[13611]: DEBUG => Starting TLS
Aug 02 13:29:55 srvXXXXX sendemail[13611]: INFO => Sending:     STARTTLS
Aug 02 13:29:55 srvXXXXX sendemail[13611]: DEBUG => evalSMTPresponse() - Found SMTP success code: 220
Aug 02 13:29:55 srvXXXXX sendemail[13611]: SUCCESS => Received:         220 2.0.0 Ready to start TLS
*******************************************************************
 Using the default of SSL_verify_mode of SSL_VERIFY_NONE for client
 is deprecated! Please set SSL_verify_mode to SSL_VERIFY_PEER
 possibly with SSL_ca_file|SSL_ca_path for verification.
 If you really don't want to verify the certificate and keep the
 connection open to Man-In-The-Middle attacks please set
 SSL_verify_mode explicitly to SSL_VERIFY_NONE in your application.
*******************************************************************
  at /usr/bin/sendemail line 1908.
Aug 02 13:29:55 srvXXXXX sendemail[13611]: DEBUG => TLS session initialized :)
Aug 02 13:29:55 srvXXXXX sendemail[13611]: INFO => Sending:     EHLO srvXXXXX
Aug 02 13:29:55 srvXXXXX sendemail[13611]: DEBUG => evalSMTPresponse() - Found SMTP success code: 250
Aug 02 13:29:55 srvXXXXX sendemail[13611]: SUCCESS => Received:         250-smtp.gmail.com at your service, [85.244.XX.XX], 250-SIZE 35882577, 250-8BITMIME, 250-AUTH LOGIN PLAIN XOAUTH2 PLAIN-CLIENTTOKEN OAUTHBEARER XOAUTH, 250-ENHANCEDSTATUSCODES, 250-PIPELINING, 250-CHUNKING, 250 SMTPUTF8
Aug 02 13:29:55 srvXXXXX sendemail[13611]: DEBUG => SMTP-AUTH: Using LOGIN authentication method
Aug 02 13:29:55 srvXXXXX sendemail[13611]: INFO => Sending:     AUTH LOGIN
Aug 02 13:29:55 srvXXXXX sendemail[13611]: DEBUG => evalSMTPresponse() - Found SMTP success code: 334
Aug 02 13:29:55 srvXXXXX sendemail[13611]: SUCCESS => Received:         334 VXNlcm5hbWU6
Aug 02 13:29:55 srvXXXXX sendemail[13611]: INFO => Sending:     cmVkb3drQGdtYWlsLmNvbQ==
Aug 02 13:29:55 srvXXXXX sendemail[13611]: DEBUG => evalSMTPresponse() - Found SMTP success code: 334
Aug 02 13:29:55 srvXXXXX sendemail[13611]: SUCCESS => Received:         334 UGFzc3dvcmQ6
Aug 02 13:29:55 srvXXXXX sendemail[13611]: INFO => Sending:     eWJweHh0cGN2cHBwYXdrbg==
Aug 02 13:29:55 srvXXXXX sendemail[13611]: DEBUG => evalSMTPresponse() - Found SMTP success code: 235
Aug 02 13:29:55 srvXXXXX sendemail[13611]: SUCCESS => Received:         235 2.7.0 Accepted
Aug 02 13:29:55 srvXXXXX sendemail[13611]: DEBUG => User authentication was successful (Method: LOGIN)
Aug 02 13:29:55 srvXXXXX sendemail[13611]: INFO => Sending:     MAIL FROM:<from@gmail.com>
Aug 02 13:29:55 srvXXXXX sendemail[13611]: DEBUG => evalSMTPresponse() - Found SMTP success code: 250
Aug 02 13:29:55 srvXXXXX sendemail[13611]: SUCCESS => Received:         250 2.1.0 OK n11sm12221358wmi.15 - gsmtp
Aug 02 13:29:55 srvXXXXX sendemail[13611]: INFO => Sending:     RCPT TO:<to@gmail.com>
Aug 02 13:29:55 srvXXXXX sendemail[13611]: DEBUG => evalSMTPresponse() - Found SMTP success code: 250
Aug 02 13:29:55 srvXXXXX sendemail[13611]: SUCCESS => Received:         250 2.1.5 OK n11sm12221358wmi.15 - gsmtp
Aug 02 13:29:55 srvXXXXX sendemail[13611]: INFO => Sending:     DATA
Aug 02 13:29:55 srvXXXXX sendemail[13611]: DEBUG => evalSMTPresponse() - Found SMTP success code: 354
Aug 02 13:29:55 srvXXXXX sendemail[13611]: SUCCESS => Received:         354  Go ahead n11sm12221358wmi.15 - gsmtp
Aug 02 13:29:55 srvXXXXX sendemail[13611]: INFO => Sending message body
Aug 02 13:29:55 srvXXXXX sendemail[13611]: Setting content-type: text/plain
Aug 02 13:29:56 srvXXXXX sendemail[13611]: DEBUG => evalSMTPresponse() - Found SMTP success code: 250
Aug 02 13:29:56 srvXXXXX sendemail[13611]: SUCCESS => Received:         250 2.0.0 OK  1596371397 n11sm12221358wmi.15 - gsmtp
Aug 02 13:29:56 srvXXXXX sendemail[13611]: Email was sent successfully!  From: <from@gmail.com> To: <to@gmail.com> Subject: [TESTSUBJECT] Server: [smtp.gmail.com:587]
[13:29 srvXXXXX ~]#